### PR TITLE
Clarified description of branch() method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ And here are the operations that will need to write to your git repository.
      g.reset # defaults to HEAD
      g.reset_hard(Git::Commit)
 
-     g.branch('new_branch') # creates new or fetches existing
+     g.branch('new_branch') # creates a Git::Branch object representing the new or existing branch
+     g.branch('new_branch').create # creates a branch in the repository but does not check it out
      g.branch('new_branch').checkout
      g.branch('new_branch').delete
      g.branch('existing_branch').checkout


### PR DESCRIPTION
The text in the README could be read as saying that calling `g.branch('new_branch')` creates a branch in the repository. However, it only creates a `Git::Branch` object. To create a branch in the repository, a user needs to call `g.branch('new_branch').create` or `g.branch('new_branch').checkout`.